### PR TITLE
Set enable default to True

### DIFF
--- a/appmacgest/models.py
+++ b/appmacgest/models.py
@@ -41,7 +41,7 @@ class Device(models.Model):
         validators=[RegexValidator(regex="^([0-9a-f]{2}[:]){5}([0-9a-f]{2})$")],
     )
     accepted = models.BooleanField(default=False)
-    enable = models.BooleanField(default=False)
+    enable = models.BooleanField(default=True)
 
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
Les mac en attentes n'apparaisse pas dans la liste, le champ enable vaut désormais True par défaut ainsi, les macs en attente de validation apparaisse correctement