### PR TITLE
Separate entity model

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -50,7 +50,7 @@ class EntiteSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Entity
-        fields = ("id", "name", "description", "color")
+        fields = ("id", "nom", "description", "color")
 
 
 class ConsommateurSerializer(serializers.HyperlinkedModelSerializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -29,6 +29,9 @@ class PermissionsSerializer(serializers.Serializer):
     groupes = serializers.ListField(
         child=serializers.CharField()
     )
+    entities = serializers.ListField(
+        child=serializers.CharField()
+    )
     recharge = serializers.BooleanField()
 
 
@@ -46,8 +49,8 @@ class ProduitSerializer(serializers.HyperlinkedModelSerializer):
 class EntiteSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
-        model = Groupe
-        fields = ("name", "color")
+        model = Entity
+        fields = ("name", "description", "color")
 
 
 class ConsommateurSerializer(serializers.HyperlinkedModelSerializer):
@@ -108,7 +111,7 @@ class BucquageSerializer(serializers.HyperlinkedModelSerializer):
 
     def create(self, validated_data):
         request = self.context.get("request")
-        bucqueur = request.user
+        bucqueur = Utilisateur.objects.get(pk=request.user.pk)
         try:
             consommateur = Consommateur.objects.get(
                 pk=validated_data["cible_bucquage"]["id"]
@@ -125,7 +128,7 @@ class BucquageSerializer(serializers.HyperlinkedModelSerializer):
         if consommateur.solde - produit.prix < 0:
             raise serializers.ValidationError("Consommateur has not enough money")
         if (
-            bucqueur.groups.filter(name=produit.entite).exists()
+            bucqueur.entities.filter(pk=produit.entite.pk).exists()
             or bucqueur.is_superuser
         ):
             validated_data["cible_bucquage"] = consommateur

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -50,7 +50,7 @@ class EntiteSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Entity
-        fields = ("name", "description", "color")
+        fields = ("id", "name", "description", "color")
 
 
 class ConsommateurSerializer(serializers.HyperlinkedModelSerializer):

--- a/api/views.py
+++ b/api/views.py
@@ -35,6 +35,7 @@ class PermissionsViewSet(viewsets.ModelViewSet):
         for ip in ips:
             data["ipIdentification"].append(ip.groupe)
         data["groupes"] = user.groups.all()
+        data["entities"] = user.entities.all()
         data["recharge"] = user.has_perm("appkfet.add_recharge")
         serializer = self.get_serializer(data)
         return Response(serializer.data)
@@ -66,7 +67,7 @@ class ProduitViewSet(viewsets.ModelViewSet):
 
 # GET : recuperer les groupes (catégories)
 class EntiteViewSet(viewsets.ModelViewSet):
-    queryset = Groupe.objects.filter(is_entity=True)
+    queryset = Entity.objects.all()
     serializer_class = EntiteSerializer
     http_method_names = ["get", "options"]
     permission_classes = (permissions.DjangoModelPermissions,)

--- a/api/views.py
+++ b/api/views.py
@@ -69,7 +69,7 @@ class ProduitViewSet(viewsets.ModelViewSet):
 class EntiteViewSet(viewsets.ModelViewSet):
     queryset = Entity.objects.all()
     serializer_class = EntiteSerializer
-    http_method_names = ["get", "options"]
+    http_method_names = ["get", "options", "post", "put", "delete"]
     permission_classes = (permissions.DjangoModelPermissions,)
 
 

--- a/appkfet/admin.py
+++ b/appkfet/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from appuser.models import Groupe
 
-from .models import Consommateur, Produit, AuthorizedIP
+from .models import Consommateur, Produit, AuthorizedIP, Entity
 
 
 @admin.register(Consommateur)
@@ -32,15 +32,6 @@ class AdminProduit(admin.ModelAdmin):
     search_fields = ["nom", "raccourci", "entite"]
     list_display = ("nom", "prix", "raccourci", "entite")
 
-    # récupérer uniquement les groupes qui sont des entités, c'est à dire ceux qui ne commencent pas par un "_"
-    def formfield_for_foreignkey(self, db_field, request, **kwargs):
-        if db_field.name == "entite":
-            qs = Groupe.objects.exclude(is_entity=False)
-            if not request.user.is_superuser:
-                qs = request.user.groups.exclude(groupe__is_entity=False)
-            kwargs["queryset"] = qs
-        return super().formfield_for_foreignkey(db_field, request, **kwargs)
-
     def has_change_permission(self, request, obj=None):
         if "appkfet.change_produit" not in request.user.get_all_permissions():
             return False
@@ -63,6 +54,9 @@ class AdminHistory(admin.ModelAdmin):
         "initiateur_evenement",
     )
 
+@admin.register(Entity)
+class AdminEntity(admin.ModelAdmin):
+    list_display = ("nom", "color")
 
 @admin.register(AuthorizedIP)
 class AdminAuthorizedIP(admin.ModelAdmin):

--- a/appkfet/admin.py
+++ b/appkfet/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from appuser.models import Groupe
+from .forms import EntityForm
 
 from .models import Consommateur, Produit, AuthorizedIP, Entity
 
@@ -57,6 +58,7 @@ class AdminHistory(admin.ModelAdmin):
 
 @admin.register(Entity)
 class AdminEntity(admin.ModelAdmin):
+    form = EntityForm
     list_display = ("nom", "color")
 
 @admin.register(AuthorizedIP)

--- a/appkfet/admin.py
+++ b/appkfet/admin.py
@@ -54,6 +54,7 @@ class AdminHistory(admin.ModelAdmin):
         "initiateur_evenement",
     )
 
+
 @admin.register(Entity)
 class AdminEntity(admin.ModelAdmin):
     list_display = ("nom", "color")

--- a/appkfet/forms.py
+++ b/appkfet/forms.py
@@ -1,0 +1,14 @@
+from django import forms
+
+from appkfet.models import Entity
+
+
+class EntityForm(forms.ModelForm):
+
+    class Meta:
+        model = Entity
+        fields = "__all__"
+        widgets = {
+                'color': forms.widgets.TextInput(attrs={'type': 'color'}),
+            }
+

--- a/appkfet/models.py
+++ b/appkfet/models.py
@@ -36,10 +36,11 @@ class Consommateur(models.Model):
         self.totaldep += montant
         self.save()
 
+
 # Model utilisé pour stocker les entités disponible sur le site kfet
 class Entity(models.Model):
     nom = models.CharField(max_length=50)
-    description = models.CharField(max_length=200)
+    description = models.CharField(max_length=200, blank=True)
     color = models.CharField(max_length=7, default="#000000")
 
     def __str__(self):

--- a/appkfet/models.py
+++ b/appkfet/models.py
@@ -116,6 +116,17 @@ class History(models.Model):
         return self.pk
 
 
+# Model utilisé pour stocker les entités disponible sur le site kfet
+# Contient un Nom, une description et un ou plusieurs groupe associé qui pourront accéder à l'entité
+class Entity(models.Model):
+    nom = models.CharField(max_length=50)
+    description = models.CharField(max_length=200)
+    groupe = models.ManyToManyField(Group)
+
+    def __str__(self):
+        return self.nom
+
+
 class AuthorizedIP(models.Model):
     groupe = models.ForeignKey("appuser.Groupe", on_delete=CASCADE)
     ip = models.GenericIPAddressField(protocol='IPv4')

--- a/appkfet/models.py
+++ b/appkfet/models.py
@@ -36,12 +36,20 @@ class Consommateur(models.Model):
         self.totaldep += montant
         self.save()
 
+# Model utilisé pour stocker les entités disponible sur le site kfet
+class Entity(models.Model):
+    nom = models.CharField(max_length=50)
+    description = models.CharField(max_length=200)
+    color = models.CharField(max_length=7, default="#000000")
+
+    def __str__(self):
+        return self.nom
 
 class Produit(models.Model):
     nom = models.CharField(max_length=50)
     prix = models.DecimalField(max_digits=5, decimal_places=2)
     raccourci = models.CharField(max_length=3)
-    entite = models.ForeignKey(Group, on_delete=CASCADE)
+    entite = models.ForeignKey(Entity, on_delete=CASCADE)
 
     def __str__(self):
         return self.nom
@@ -115,16 +123,6 @@ class History(models.Model):
     def __unicode__(self):
         return self.pk
 
-
-# Model utilisé pour stocker les entités disponible sur le site kfet
-# Contient un Nom, une description et un ou plusieurs groupe associé qui pourront accéder à l'entité
-class Entity(models.Model):
-    nom = models.CharField(max_length=50)
-    description = models.CharField(max_length=200)
-    groupe = models.ManyToManyField(Group)
-
-    def __str__(self):
-        return self.nom
 
 
 class AuthorizedIP(models.Model):

--- a/appuser/admin.py
+++ b/appuser/admin.py
@@ -1,7 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.models import User, Group
 from .models import Utilisateur, Groupe
-from .forms import GroupeForm
 
 class AdminUtilisateur(admin.ModelAdmin):
     search_fields = ["username", "first_name", "last_name", "phone", "email", "bucque", "fams", "proms", "chambre"]
@@ -21,7 +20,6 @@ class AdminUtilisateur(admin.ModelAdmin):
     )
 
 class AdminGroupe(admin.ModelAdmin):
-    form = GroupeForm
     list_display = (
         "name",
     )

--- a/appuser/forms.py
+++ b/appuser/forms.py
@@ -91,11 +91,3 @@ class CustomPasswordResetForm(PasswordResetForm):
     )
 
 
-class GroupeForm(forms.ModelForm):
-
-    class Meta:
-        model = Groupe
-        fields = "__all__"
-        widgets = {
-                'color': forms.widgets.TextInput(attrs={'type': 'color'}),
-            }

--- a/appuser/models.py
+++ b/appuser/models.py
@@ -9,6 +9,8 @@ from datetime import date
 
 from django.contrib.auth.models import User, Group
 from django.db import models
+
+
 from db import WITHLDAP
 from django.db.models.signals import post_save, post_delete, m2m_changed
 from django.dispatch.dispatcher import receiver
@@ -55,10 +57,18 @@ class Utilisateur(User):
     def __unicode__(self):
         return self.username
 
+    #fonction entities renvoyant la liste des entités auxquelles appartient l'utilisateur en passant par ses groupes
+    # Entities est considéré comme un attribut de l'utilisateur
+    @property
+    def entities(self):
+        from appkfet.models import Entity
+        return Entity.objects.filter(groups__in=self.groups.all()).distinct()
+
+
 #surcharge du modèle Group de base pour lui rajouter cet attribut d'entité
 class Groupe(Group):
-    is_entity = models.BooleanField(default=False)
-    color = models.CharField(max_length=7, default="#000000")
+    from appkfet.models import Entity
+    entities = models.ManyToManyField(Entity, blank=True, related_name="groups")
 
 #si l'application fonctionne avec le LDAP, alors : 
 if WITHLDAP:


### PR DESCRIPTION
Séparation des entités des groupes. En effet comme les groupes servent à gérer les permissions il peut y avoir des groupes différents qui ont accès à la même entité. Par ex : vp_cvis et team_cvis sont 2 groupes accédants tous deux à l'entité cvis