### PR TITLE
fix accès aux endpoint sans consommateur lié à l'user

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -38,6 +38,9 @@ class AllowedIPEvenSaveMethods(permissions.BasePermission):
     def has_permission(self, request, view):
         return _is_ip_authorized(request)
 
+class RequiersConsommateur(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return Consommateur.objects.filter(consommateur=request.user.pk, activated=True).exists()
 
 
 

--- a/api/views.py
+++ b/api/views.py
@@ -7,7 +7,7 @@ from rest_framework import status
 from api.serializers import *
 
 from api.permissions import AllowedIP, AllowedIPEvenSaveMethods, get_client_ip, EditEventPermission, \
-    EditProductEventPermission, BucquageEventPermission
+    EditProductEventPermission, BucquageEventPermission, RequiersConsommateur
 
 
 
@@ -45,7 +45,7 @@ class PermissionsViewSet(viewsets.ModelViewSet):
 class CurrentUserViewSet(viewsets.ModelViewSet):
     serializer_class = ConsommateurSerializer
     http_method_names = ["get", "options"]
-    permission_classes = (permissions.DjangoModelPermissions,)
+    permission_classes = (permissions.DjangoModelPermissions, RequiersConsommateur,)
     queryset = Consommateur.objects.none()
 
     def list(self, request):
@@ -62,7 +62,7 @@ class ProduitViewSet(viewsets.ModelViewSet):
     queryset = Produit.objects.all()
     serializer_class = ProduitSerializer
     http_method_names = ["get", "options"]
-    permission_classes = (permissions.DjangoModelPermissions,)
+    permission_classes = (permissions.DjangoModelPermissions, RequiersConsommateur,)
 
 
 # GET : recuperer les groupes (catégories)
@@ -70,7 +70,7 @@ class EntiteViewSet(viewsets.ModelViewSet):
     queryset = Entity.objects.all()
     serializer_class = EntiteSerializer
     http_method_names = ["get", "options", "post", "put", "delete"]
-    permission_classes = (permissions.DjangoModelPermissions,)
+    permission_classes = (permissions.DjangoModelPermissions, RequiersConsommateur,)
 
 
 # GET : récupérer tous les consommateurs
@@ -78,7 +78,7 @@ class ConsommateurViewSet(viewsets.ModelViewSet):
     queryset = Consommateur.objects.filter(activated=True)
     serializer_class = ConsommateurSerializer
     http_method_names = ["get", "options"]
-    permission_classes = (permissions.DjangoModelPermissions,)
+    permission_classes = (permissions.DjangoModelPermissions, RequiersConsommateur,)
 
 
 # GET : récupérer toutes les recharges pour tous les utilisateurs ou pour un en particulier
@@ -87,7 +87,7 @@ class ConsommateurViewSet(viewsets.ModelViewSet):
 class RechargeViewSet(viewsets.ModelViewSet):
     serializer_class = RechargeSerializer
     http_method_names = ["get", "post", "options"]
-    permission_classes = (permissions.DjangoModelPermissions, AllowedIP,)
+    permission_classes = (permissions.DjangoModelPermissions, RequiersConsommateur, AllowedIP,)
     lookup_field = "cible_recharge"
 
     def get_queryset(self, *args, **kwargs):
@@ -123,7 +123,7 @@ class BucquageViewSet(viewsets.ModelViewSet):
     serializer_class = BucquageSerializer
     http_method_names = ["get", "post", "options"]
     lookup_field = "cible_bucquage"
-    permission_classes = (permissions.DjangoModelPermissions, AllowedIP,)
+    permission_classes = (permissions.DjangoModelPermissions, RequiersConsommateur, AllowedIP,)
 
     def get_queryset(self, *args, **kwargs):
         if "cible_bucquage" in self.kwargs:
@@ -154,7 +154,7 @@ class BucquageViewSet(viewsets.ModelViewSet):
 # récupérer l'historique pour un utilisateur donné ou pour tous
 class HistoryViewSet(viewsets.ModelViewSet):
     http_method_names = ["get", "options"]
-    permission_classes = (permissions.DjangoModelPermissions,)
+    permission_classes = (permissions.DjangoModelPermissions, RequiersConsommateur,)
     serializer_class = HistorySerializer
     lookup_field = "cible_evenement"
 
@@ -185,7 +185,7 @@ class HistoryViewSet(viewsets.ModelViewSet):
 class RechargeLydiaViewSet(viewsets.ModelViewSet):
     serializer_class = RechargeLydiaSerializer
     http_method_names = ["get", "post", "options"]
-    permission_classes = (permissions.DjangoModelPermissions, AllowedIP,)
+    permission_classes = (permissions.DjangoModelPermissions, RequiersConsommateur, AllowedIP,)
     lookup_field = "cible_recharge"
 
     def get_queryset(self, *args, **kwargs):
@@ -214,7 +214,7 @@ class RechargeLydiaViewSet(viewsets.ModelViewSet):
 # POST : Ajoute un evenement (sous permissions addEvent)
 class EventViewSet(viewsets.ModelViewSet):
     serializer_class = EventSerializer
-    permission_classes = (EditEventPermission,)  #On combine les permissions de bases et la perm custom pour overide uniquement les permissions de modification d'objet
+    permission_classes = (RequiersConsommateur, EditEventPermission,)  #On combine les permissions de bases et la perm custom pour overide uniquement les permissions de modification d'objet
     http_method_names = ["get", "options", "post", "patch", "put", "delete"]
 
     def get_queryset(self):
@@ -229,7 +229,7 @@ class EventViewSet(viewsets.ModelViewSet):
 # Filter : finss=<id finss> --> renvoi les produits du finss passer en argument url
 class ProductEventViewSet(viewsets.ModelViewSet):
     serializer_class = ProductEventSerializer
-    permission_classes = (EditProductEventPermission,) # On combine les permissions de bases et la perm custom pour overide uniquement les permissions de modification d'objet
+    permission_classes = (RequiersConsommateur, EditProductEventPermission,) # On combine les permissions de bases et la perm custom pour overide uniquement les permissions de modification d'objet
     http_method_names = ["get", "options", "post", "patch", "put", "delete"]
     queryset = ProductEvent.objects.all()
 
@@ -255,7 +255,7 @@ class ProductEventViewSet(viewsets.ModelViewSet):
 #                                  [{consommateur_id:id, participation:[liste des participations de l'utilisateur}, ...]
 # Filter : finss=<id finss> --> filtre les participations qui ne concernent que le finss id finss
 class BucqageEventViewSet(viewsets.ModelViewSet):
-    permission_classes = (BucquageEventPermission,)
+    permission_classes = (RequiersConsommateur, BucquageEventPermission,)
 
     def get_serializer_class(self):
         if self.action == "list":


### PR DESCRIPTION
ajout classe RequiersConsommateur pour vérifier que l'utilisateur qui accède aux endpoint est associé à un consommateur actif (définie dans api/permissions.py)

ajout de RequiersConsommateur dans la liste permission_classes des viewSets de api/views.py