### PR TITLE
Annuler le dernier bucquage

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -186,6 +186,7 @@ class BucquageSerializer(serializers.HyperlinkedModelSerializer):
             validated_data["nom_produit"] = produit.nom
             validated_data["prix_produit"] = produit.prix
             validated_data["entite_produit"] = produit.entite
+            validated_data["produit"] = produit
             validated_data["initiateur_evenement"] = Utilisateur.objects.get(id=request.user.pk)
             produit.bucquage()
             return Bucquage.objects.create(**validated_data)

--- a/api/views.py
+++ b/api/views.py
@@ -3,6 +3,8 @@ from rest_framework import permissions
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework import status
+from datetime import timedelta
+from django.utils import timezone
 
 from api.serializers import *
 
@@ -110,6 +112,33 @@ class ConsommateurViewSet(viewsets.ModelViewSet):
     serializer_class = ConsommateurSerializer
     http_method_names = ["get", "options"]
     permission_classes = (permissions.DjangoModelPermissions, RequiersConsommateur,)
+
+    @action(methods=['POST'], detail=True)
+    def annulerDernierDebucquage(self, request, pk=None):
+        request_user = Utilisateur.objects.get(pk=request.user.pk)
+        try:
+            consommateur = Consommateur.objects.get(pk=pk)
+        except Consommateur.DoesNotExist:
+            return Response({"Cannot resolve consommateur"}, status=status.HTTP_400_BAD_REQUEST)
+
+        last_debucquage = consommateur.getDernierDebucquage()
+
+        if last_debucquage is None:
+            return Response({"detail": "Aucun débucquage pour ce consommateur"}, status=status.HTTP_400_BAD_REQUEST)
+
+        if timezone.now() - last_debucquage.date > timedelta(minutes=5):
+            return Response({"detail": "Vous ne pouvez annuler un débucquage exécuté il y a plus de 5 minutes"}, status=status.HTTP_403_FORBIDDEN)
+
+        # TODO? perm pour bypass
+        if last_debucquage.initiateur_evenement != request_user:
+            return Response({"detail": "Vous ne pouvez pas annuler un débucquage executé par un autre utilisateur"}, status=status.HTTP_403_FORBIDDEN)
+
+        res, message = last_debucquage.annuler()
+        if res:
+            return Response({"detail": "Débucquage '"+str(message)+"' annulé"}, status=status.HTTP_200_OK)
+        else:
+            return Response({"detail": message}, status=status.HTTP_400_BAD_REQUEST)
+
 
 
 # GET : récupérer toutes les recharges pour tous les utilisateurs ou pour un en particulier

--- a/api/views.py
+++ b/api/views.py
@@ -12,7 +12,6 @@ from api.permissions import AllowedIP, AllowedIPEvenSaveMethods, get_client_ip, 
     EditProductEventPermission, BucquageEventPermission, RequiersConsommateur, ProduitPermission
 
 
-
 ########################
 #         KFET         #
 ########################
@@ -97,7 +96,6 @@ class ProduitByEntityViewSet(viewsets.ModelViewSet):
         return Response(data=serializer.data)
 
 
-
 # GET : recuperer les groupes (catégories)
 class EntiteViewSet(viewsets.ModelViewSet):
     queryset = Entity.objects.all()
@@ -127,18 +125,19 @@ class ConsommateurViewSet(viewsets.ModelViewSet):
             return Response({"detail": "Aucun débucquage pour ce consommateur"}, status=status.HTTP_400_BAD_REQUEST)
 
         if timezone.now() - last_debucquage.date > timedelta(minutes=5):
-            return Response({"detail": "Vous ne pouvez annuler un débucquage exécuté il y a plus de 5 minutes"}, status=status.HTTP_403_FORBIDDEN)
+            return Response({"detail": "Vous ne pouvez annuler un débucquage exécuté il y a plus de 5 minutes"},
+                            status=status.HTTP_403_FORBIDDEN)
 
         # TODO? perm pour bypass
         if last_debucquage.initiateur_evenement != request_user:
-            return Response({"detail": "Vous ne pouvez pas annuler un débucquage executé par un autre utilisateur"}, status=status.HTTP_403_FORBIDDEN)
+            return Response({"detail": "Vous ne pouvez pas annuler un débucquage executé par un autre utilisateur"},
+                            status=status.HTTP_403_FORBIDDEN)
 
         res, message = last_debucquage.annuler()
         if res:
-            return Response({"detail": "Débucquage '"+str(message)+"' annulé"}, status=status.HTTP_200_OK)
+            return Response({"detail": "Débucquage '" + str(message) + "' annulé"}, status=status.HTTP_200_OK)
         else:
             return Response({"detail": message}, status=status.HTTP_400_BAD_REQUEST)
-
 
 
 # GET : récupérer toutes les recharges pour tous les utilisateurs ou pour un en particulier

--- a/api/views.py
+++ b/api/views.py
@@ -108,10 +108,10 @@ class EntiteViewSet(viewsets.ModelViewSet):
 class ConsommateurViewSet(viewsets.ModelViewSet):
     queryset = Consommateur.objects.filter(activated=True)
     serializer_class = ConsommateurSerializer
-    http_method_names = ["get", "options"]
+    http_method_names = ["get", "options", "patch"]
     permission_classes = (permissions.DjangoModelPermissions, RequiersConsommateur,)
 
-    @action(methods=['POST'], detail=True)
+    @action(methods=['PATCH'], detail=True)
     def annulerDernierDebucquage(self, request, pk=None):
         request_user = Utilisateur.objects.get(pk=request.user.pk)
         try:
@@ -139,6 +139,8 @@ class ConsommateurViewSet(viewsets.ModelViewSet):
         else:
             return Response({"detail": message}, status=status.HTTP_400_BAD_REQUEST)
 
+    def create(self, request, *args, **kwargs):
+        return Response({"detail": "Create non autorisée"}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 # GET : récupérer toutes les recharges pour tous les utilisateurs ou pour un en particulier
 # POST : créer une recharge. Seuls les utilisateurs ayant été déclaré avec le droit appkfet|recharge|can add recharge

--- a/api/views.py
+++ b/api/views.py
@@ -117,7 +117,7 @@ class ConsommateurViewSet(viewsets.ModelViewSet):
         try:
             consommateur = Consommateur.objects.get(pk=pk)
         except Consommateur.DoesNotExist:
-            return Response({"Cannot resolve consommateur"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"detail": "Consommateur non trouvé"}, status=status.HTTP_404_NOT_FOUND)
 
         last_debucquage = consommateur.getDernierDebucquage()
 

--- a/appkfet/models.py
+++ b/appkfet/models.py
@@ -36,6 +36,11 @@ class Consommateur(models.Model):
         self.totaldep += montant
         self.save()
 
+    def getDernierDebucquage(self):
+        """Renvoie le dernier bucquage effectué pour ce consommateur"""
+        return Bucquage.objects.filter(cible_bucquage=self).order_by("-date").first()
+
+
 
 # Model utilisé pour stocker les entités disponible sur le site kfet
 class Entity(models.Model):
@@ -130,6 +135,37 @@ class Bucquage(models.Model):
                 date_evenement=self.date,
                 initiateur_evenement=self.initiateur_evenement,
             )
+
+    def annuler(self):
+        """Annulation du bucquage, avec recréditation du solde du consommateur, incrémentation du stock (si besoin),
+        modification de l'historique et enfin suppression de l'objet bucquage"""
+        try:
+            produit = Produit.objects.get(nom=self.nom_produit, entite=Entity.objects.get(nom=self.entite_produit))  # peut poser problème si le couple (nom, entite) n'est pas unique
+        except Produit.DoesNotExist:
+            return False, "le produit n'existe pas"
+
+        num_rows_matched = History.objects.filter(
+            cible_evenement=self.cible_bucquage,
+            nom_evenement=self.nom_produit,
+            prix_evenement=self.prix_produit,
+            entite_evenement=self.entite_produit,
+            date_evenement=self.date,
+            initiateur_evenement=self.initiateur_evenement,
+        ).update(
+            nom_evenement="annulé - " + str(self.nom_produit)
+        )
+        # on s'assure qu'il y aura une entrée dans l'historique pour log l'annulation avant de supprimer l'objet Bucquage
+        if num_rows_matched == 0:
+            return False, "aucune entrée dans l'historique trouvé"
+
+        Consommateur.credit(self.cible_bucquage, self.prix_produit)
+        if produit.suivi_stock:
+            produit.stock += 1
+            produit.save()
+
+        nom_produit = str(self.nom_produit)
+        self.delete()
+        return True, nom_produit
 
     def __unicode__(self):
         return self.pk

--- a/appkfet/models.py
+++ b/appkfet/models.py
@@ -41,7 +41,6 @@ class Consommateur(models.Model):
         return Bucquage.objects.filter(cible_bucquage=self).order_by("-date").first()
 
 
-
 # Model utilisé pour stocker les entités disponible sur le site kfet
 class Entity(models.Model):
     nom = models.CharField(max_length=50, unique=True)
@@ -50,6 +49,7 @@ class Entity(models.Model):
 
     def __str__(self):
         return self.nom
+
 
 class Produit(models.Model):
     nom = models.CharField(max_length=50)
@@ -140,7 +140,8 @@ class Bucquage(models.Model):
         """Annulation du bucquage, avec recréditation du solde du consommateur, incrémentation du stock (si besoin),
         modification de l'historique et enfin suppression de l'objet bucquage"""
         try:
-            produit = Produit.objects.get(nom=self.nom_produit, entite=Entity.objects.get(nom=self.entite_produit))  # peut poser problème si le couple (nom, entite) n'est pas unique
+            produit = Produit.objects.get(nom=self.nom_produit, entite=Entity.objects.get(
+                nom=self.entite_produit))  # peut poser problème si le couple (nom, entite) n'est pas unique
         except Produit.DoesNotExist:
             return False, "le produit n'existe pas"
 
@@ -181,7 +182,6 @@ class History(models.Model):
 
     def __unicode__(self):
         return self.pk
-
 
 
 class AuthorizedIP(models.Model):

--- a/appkfet/models.py
+++ b/appkfet/models.py
@@ -121,6 +121,7 @@ class Bucquage(models.Model):
     nom_produit = models.CharField(max_length=50)
     prix_produit = models.DecimalField(max_digits=5, decimal_places=2)
     entite_produit = models.CharField(max_length=50)
+    produit = models.ForeignKey(Produit, on_delete=models.SET_NULL, null=True)
     initiateur_evenement = models.ForeignKey("appuser.Utilisateur", on_delete=CASCADE)
 
     def save(self, *args, **kwargs):
@@ -139,11 +140,8 @@ class Bucquage(models.Model):
     def annuler(self):
         """Annulation du bucquage, avec recréditation du solde du consommateur, incrémentation du stock (si besoin),
         modification de l'historique et enfin suppression de l'objet bucquage"""
-        try:
-            produit = Produit.objects.get(nom=self.nom_produit, entite=Entity.objects.get(
-                nom=self.entite_produit))  # peut poser problème si le couple (nom, entite) n'est pas unique
-        except Produit.DoesNotExist:
-            return False, "le produit n'existe pas"
+        if self.produit is None:
+            return False, "le produit n'existe plus"
 
         num_rows_matched = History.objects.filter(
             cible_evenement=self.cible_bucquage,
@@ -160,9 +158,9 @@ class Bucquage(models.Model):
             return False, "aucune entrée dans l'historique trouvé"
 
         Consommateur.credit(self.cible_bucquage, self.prix_produit)
-        if produit.suivi_stock:
-            produit.stock += 1
-            produit.save()
+        if self.produit.suivi_stock:
+            self.produit.stock += 1
+            self.produit.save()
 
         nom_produit = str(self.nom_produit)
         self.delete()


### PR DESCRIPTION
Ajout d'une action /annulerDernierDebucquage en POST sous l'endpoint /consommateurs/[id]/

Pour que le dernier bucquage puisse être annulé, il doit:
- avoir été effectué il y a moins de 5 minutes
- avoir été fait par le même utilisateur qui fait la requête pour annuler

Si ces conditions sont vérifier, la table Historique est modifié pour ajouter l'information que le débucquage est annulé, le consommateur est créditer, le stock du produit est incrémenté, et on supprime de la table Bucquage le bucquage qui vient d'être annulé.