### PR TITLE
change maclookup call

### DIFF
--- a/niki/settings.py
+++ b/niki/settings.py
@@ -258,7 +258,7 @@ TINYMCE_DEFAULT_CONFIG = {
 # Maclookup defined in settings to update the vendor list
 BaseMacLookup.cache_path = "./.cache/mac-vendors.txt"
 MACLOOKUP = MacLookup()
-MACLOOKUP.update_vendors()
+MACLOOKUP.load_vendors()
 
 
 # Celery settings
@@ -288,7 +288,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "update_maclookup_vendors_list_task": {
         "task": "appmacgest.tasks.update_maclookup_vendors_list_task",
-        "schedule": crontab(minute=32, hour=0),
+        "schedule": crontab(minute=32, hour=0, day_of_week="tue,fri"),
     },
 
 }


### PR DESCRIPTION
Changement de la fonction dans settings par load_vendors().
Cette dernière regarde si le fichier cache existe, si oui, elle charge ses données, si non, elle les récupère sur internet.
Ceci permet d'éviter de multiplier les appels au [site](https://regauth.standards.ieee.org/standards-ra-web/pub/view.html) qui héberge les donnes des adresse mac, et qui limite les téléchargements à une fois par jour (ce qui arrive vite quand on dev et qu'on relance le serveur)

Et réduction de la période de la crontab à 2 fois par semaine