### PR TITLE
Fix check cotiz

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -25,6 +25,8 @@ RADIUS_USERNAME=
 RADIUS_PASSWORD=
 RADIUS_ADDR=
 
+# EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend" # pour le developpement
+# EMAIL_FILE_PATH = "/var/log/niki/mail"
 EMAIL_HOST=
 EMAIL_HOST_USER=
 EMAIL_HOST_PASSWORD=

--- a/appuser/admin.py
+++ b/appuser/admin.py
@@ -18,6 +18,7 @@ class AdminUtilisateur(admin.ModelAdmin):
         "is_staff",
         "is_superuser",
     )
+    readonly_fields = ("last_email_date",)
 
 class AdminGroupe(admin.ModelAdmin):
     list_display = (

--- a/appuser/tasks.py
+++ b/appuser/tasks.py
@@ -12,7 +12,7 @@ def check_user_cotiz_task():
     email_template = get_template("appuser/cotiz_expired_email.txt")
     email_content = email_template.render()
 
-    users = Utilisateur.objects.filter(Q(is_active=True) & Q(date_expiration=date.today()))
+    users = Utilisateur.objects.filter(Q(has_cotiz=True) & Q(date_expiration__lte=date.today()))
 
     emails = []
     for user in users:
@@ -21,20 +21,23 @@ def check_user_cotiz_task():
 
         emails.append(('Niki - Votre cotisation au rezal a expirée', email_content, None, [user.email]))
 
+    print(f"{len(users)} utilisateurs désactivés")
     send_mass_mail(emails)
+
 
 @shared_task()
 def send_mail_for_cotiz_task():
     email_template = get_template("appuser/cotiz_will_expire_email.txt")
 
-    #On sélectionne les users actifs qui expire dans 6 jours ou moins
+    # On sélectionne les users actifs qui expire dans 6 jours ou moins
     # et qui aucun mail n'a déjà été envoyé les 2 précédents jours
 
-    users = Utilisateur.objects.filter(Q(is_active=True)
+    users = Utilisateur.objects.filter(Q(has_cotiz=True)
                                        & Q(date_expiration__gt=date.today())
-                                       & Q(date_expiration__lte=(date.today()+timedelta(days=6)))
-                                       & (Q(last_email_date__lte=(date.today()-timedelta(days=2)))
-                                          | Q(last_email_date=None))
+                                       & Q(date_expiration__lte=(date.today() + timedelta(days=6)))
+                                       & (Q(last_email_date__lte=(date.today() - timedelta(days=2)))
+                                          | Q(last_email_date=None)
+                                          )
                                        )
 
     emails = []
@@ -42,12 +45,12 @@ def send_mail_for_cotiz_task():
         context = {
             'expiry_date': user.date_expiration,
             'time_left': (user.date_expiration - date.today()).days
-            }
+        }
 
         email_content = email_template.render(context)
         emails.append(('Niki - Expiration de votre cotisation au rezal', email_content, None, [user.email]))
         user.last_email_date = date.today()
         user.save()
 
+    print(f"{len(users)} utilisateurs contactés")
     send_mass_mail(emails)
-

--- a/appuser/tasks.py
+++ b/appuser/tasks.py
@@ -10,7 +10,6 @@ from datetime import date, timedelta
 @shared_task()
 def check_user_cotiz_task():
     email_template = get_template("appuser/cotiz_expired_email.txt")
-    email_content = email_template.render()
 
     users = Utilisateur.objects.filter(Q(has_cotiz=True) & Q(date_expiration__lte=date.today()))
 
@@ -19,6 +18,11 @@ def check_user_cotiz_task():
         user.has_cotiz = False
         user.save()
 
+        context = {
+            'first_name': user.first_name,
+            'expiry_date': user.date_expiration
+        }
+        email_content = email_template.render(context)
         emails.append(('Niki - Votre cotisation au rezal a expirée', email_content, None, [user.email]))
 
     print(f"{len(users)} utilisateurs désactivés")
@@ -43,6 +47,7 @@ def send_mail_for_cotiz_task():
     emails = []
     for user in users:
         context = {
+            'first_name': user.first_name,
             'expiry_date': user.date_expiration,
             'time_left': (user.date_expiration - date.today()).days
         }

--- a/niki/settings.py
+++ b/niki/settings.py
@@ -227,7 +227,8 @@ LOGIN_URL = "login"
 LOGIN_REDIRECT_URL = "index"
 LOGOUT_REDIRECT_URL = "index"
 
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_BACKEND = getenv("EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend")
+EMAIL_FILE_PATH = getenv("EMAIL_FILE_PATH", "/var/log/niki/mail")
 EMAIL_HOST = getenv("EMAIL_HOST", "")
 EMAIL_HOST_USER = getenv("EMAIL_HOST_USER", "")
 EMAIL_HOST_PASSWORD = getenv("EMAIL_HOST_PASSWORD", "")

--- a/niki/settings.py
+++ b/niki/settings.py
@@ -281,11 +281,11 @@ CELERYBEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_BEAT_SCHEDULE = {
     "check_user_cotiz_task": {
         "task": "appuser.tasks.check_user_cotiz_task",
-        "schedule": crontab(minute=0, hour=0),
+        "schedule": crontab(minute=1, hour=0),
     },
     "send_mail_for_cotiz_task": {
         "task": "appuser.tasks.send_mail_for_cotiz_task",
-        "schedule": crontab(minute=0, hour=0),
+        "schedule": crontab(minute=2, hour=0),
     },
     "update_maclookup_vendors_list_task": {
         "task": "appmacgest.tasks.update_maclookup_vendors_list_task",

--- a/templates/appuser/cotiz_expired_email.txt
+++ b/templates/appuser/cotiz_expired_email.txt
@@ -1,5 +1,7 @@
 {% autoescape off %}
-Votre cotisation au rezal a expirée, vous n'avez donc plus accès à internet.
+Bonjour {{first_name}},
+
+Votre cotisation au rezal a expirée le {{expiry_date}}, et votre accès à internet a été désactivé.
 
 Si vous souhaitez renouveler votre cotisation, veuillez contacter l'équipe rezal : contact@rezal.fr
 

--- a/templates/appuser/cotiz_will_expire_email.txt
+++ b/templates/appuser/cotiz_will_expire_email.txt
@@ -1,4 +1,6 @@
 {% autoescape off %}
+Bonjour {{first_name}},
+
 Votre cotisation expire dans {{time_left}} jour(s).
 Pour la renouveler, veuillez contacter un membre du rezal à l'adresse contact@rezal.fr.
 


### PR DESCRIPTION
Correction des attributs utilisateurs vérifié pour envoyer les mails aux utilisateurs dont la cotisation va/est expiré.
(has_cotiz à la place de is_active)

Modification des templates des mails pour ajouter la date et le nom.

Ajout d'un paramètre pour choisir le backend pour les mails.
Permet notamment d'écrire les mails dans des fichiers pour le dev/debuggage.