### PR TITLE
ajout endpoint pour s'avoir si l'utilisateur à un consommateur kfet actif

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -21,6 +21,10 @@ import uuid
 from niki.settings import CASHIER_PHONE, LYDIA_URL, VENDOR_TOKEN
 
 
+class IsActivatedSerializer(serializers.Serializer):
+    is_activated = serializers.BooleanField()
+
+
 class PermissionsSerializer(serializers.Serializer):
     all = serializers.BooleanField()
     ipIdentification = serializers.ListField(

--- a/api/urls.py
+++ b/api/urls.py
@@ -4,6 +4,7 @@ from rest_framework import routers
 from . import views
 
 router = routers.DefaultRouter()
+router.register(r"is_activated", views.IsActivatedViewSet, basename="is_activated")
 router.register(r"permissions", views.PermissionsViewSet, basename="permissions")
 router.register(r"utilisateur", views.CurrentUserViewSet, basename="utilisateur")
 router.register(r"produits", views.ProduitViewSet)

--- a/api/views.py
+++ b/api/views.py
@@ -21,6 +21,19 @@ from django.http.request import QueryDict
 # GET : recupère les permissions de l'utilisateur
 
 
+class IsActivatedViewSet(viewsets.ModelViewSet):
+    serializer_class = IsActivatedSerializer
+    http_method_names = ["get", "options"]
+    permission_classes = (permissions.DjangoModelPermissions,)
+    queryset = Utilisateur.objects.none()
+
+    def list(self, request):
+        is_activated = Consommateur.objects.filter(consommateur=request.user.pk, activated=True).exists()
+        data = {"is_activated": is_activated}
+        serializer = self.get_serializer(data)
+        return Response(serializer.data)
+
+
 class PermissionsViewSet(viewsets.ModelViewSet):
     serializer_class = PermissionsSerializer
     http_method_names = ["get", "options"]


### PR DESCRIPTION
Renvoie un booléen si l'utilisateur qui fait la requête a un consommateur kfet, et que ce consommateur est actif.

Pour éviter de faire des requêtes aux autres endpoint pour la kfet et avoir des messages d'erreur si l'utilisateur est connecté, mais n'a pas de compte kfet.